### PR TITLE
Fixed async/await bug in executeInitialization function

### DIFF
--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -15,9 +15,13 @@ class Migrator {
   Migrator(this.config);
 
   Future<void> executeInitialization(Database db, int version) async {
-    config.initializationScript
-        .forEach((script) async => await db.execute(script));
-    config.migrationScripts.forEach((script) async => await db.execute(script));
+    for (String script in config.initializationScript) {
+      await db.execute(script);
+    }
+
+    for (String script in config.migrationScripts) {
+      await db.execute(script);
+    }
   }
 
   Future<void> executeMigration(


### PR DESCRIPTION
# Issue
Currently, when one of the initializationScripts or migrationScripts throws an exception, this becomes an unhandled exception.
This is because the async/await is used within a forEach loop, which doesn't actually await the iterate function.

# How to replicate
You can test this by creating an invalid initializationScript.
The openDatabaseWithMigration resolves instead of rejects, and the exception is thrown as an unhandled exception.

# Fix
By placing the execute functions in a for loop, it awaits normally, and the openDatabaseWithMigration function rejects as expected.